### PR TITLE
Add Door, History, and PermissionRequest models with schemas

### DIFF
--- a/backend/models/Door.js
+++ b/backend/models/Door.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const doorSchema = new Schema({
+  doorCode: { type: String, required: true, unique: true },
+  doorName: { type: String, required: true },
+  location: { type: String }
+}, { timestamps: true });
+
+const DoorModel = mongoose.model('Door', doorSchema);
+
+module.exports = DoorModel;

--- a/backend/models/History.js
+++ b/backend/models/History.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const historySchema = new Schema({
+  door: { type: Schema.Types.ObjectId, ref: 'Door', required: true },
+  entryTime: { type: Date, required: true },
+  exitTime: { type: Date },
+  status: { type: String, enum: ['Active', 'Exited'], default: 'Active' }
+}, { timestamps: true });
+
+const HistoryModel = mongoose.model('History', historySchema);
+
+module.exports = HistoryModel;

--- a/backend/models/PermissionRequest.js
+++ b/backend/models/PermissionRequest.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const permissionRequestSchema = new Schema({
+  user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  door: { type: Schema.Types.ObjectId, ref: 'Door', required: true },
+  requestTime: { type: Date, default: Date.now },
+  status: { type: String, enum: ['Pending', 'Approved', 'Rejected'], default: 'Pending' }
+}, { timestamps: true });
+
+const PermissionRequestModel = mongoose.model('PermissionRequest', permissionRequestSchema);
+
+module.exports = PermissionRequestModel;


### PR DESCRIPTION
This pull request includes the addition of three new Mongoose models to the backend of the application. These models are designed to handle data for doors, history of door usage, and permission requests.

New Mongoose models:

* [`backend/models/Door.js`](diffhunk://#diff-feddcb81c9a81778e57eb802d01f4e9badbc7870c9329955a5ff7cd8f8a8907bR1-R12): Added `DoorModel` schema to represent doors with fields for `doorCode`, `doorName`, and `location`.
* [`backend/models/History.js`](diffhunk://#diff-308e7c83a8202b173c286273d15fc1350914206189d53461cfe96060f887d208R1-R13): Added `HistoryModel` schema to track door usage history with fields for `door`, `entryTime`, `exitTime`, and `status`.
* [`backend/models/PermissionRequest.js`](diffhunk://#diff-c0bf5d1db1e92b76a311f8fe627a49a831196c484e54b667f3225383c7c0418dR1-R13): Added `PermissionRequestModel` schema to manage permission requests with fields for `user`, `door`, `requestTime`, and `status`.