### PR TITLE
Refactor delete methods to use deleteOne for admin and company deletion

### DIFF
--- a/backend/controllers/adminAuthController.js
+++ b/backend/controllers/adminAuthController.js
@@ -81,7 +81,7 @@ const deleteAdminUserById = async (req, res) => {
       return res.status(404).json({ error: 'Admin user not found' });
     }
 
-    await user.remove();
+    await user.deleteOne({ _id: req.params.id });
     res.json({ message: 'Admin user deleted successfully' });
   } catch (error) {
     res.status(500).json({ error: 'Server error' });

--- a/backend/controllers/companyController.js
+++ b/backend/controllers/companyController.js
@@ -80,7 +80,7 @@ const deleteCompany = async (req, res) => {
     if (!company) {
       return res.status(404).json({ error: 'Company not found' });
     }
-    await company.remove();
+    await Company.deleteOne({ _id: req.params.id });
     res.json({ message: 'Company deleted successfully' });
   } catch (error) {
     console.error('Error deleting company:', error);


### PR DESCRIPTION
This pull request includes changes to the deletion methods in the `adminAuthController` and `companyController` files to use the `deleteOne` method instead of the `remove` method.

Changes to deletion methods:

* [`backend/controllers/adminAuthController.js`](diffhunk://#diff-bddea4e858fac7f7c5d86e5f917459e5d66378297e5440f5a9c752ec0a8a3211L84-R84): Modified the `deleteAdminUserById` function to use `deleteOne` for deleting an admin user by ID.
* [`backend/controllers/companyController.js`](diffhunk://#diff-174339c631be7cd0b336b2f31e0277efc0134002b2809ffe3126a5557512822cL83-R83): Modified the `deleteCompany` function to use `deleteOne` for deleting a company by ID.